### PR TITLE
Correct filename case in #include directive

### DIFF
--- a/Zmotor2.cpp
+++ b/Zmotor2.cpp
@@ -5,7 +5,7 @@
 */
 #include <assert.h>
 
-#include "zmotor2.h"
+#include "Zmotor2.h"
 
 #include <Wire.h>
 


### PR DESCRIPTION
Incorrect capitalization of Zmotor2.h causes compilation to fail on filename case-sensitive operating systems like Linux.